### PR TITLE
fixed duplicate get endpoint issue and fixed corresponding test case

### DIFF
--- a/backend/routes/posts.ts
+++ b/backend/routes/posts.ts
@@ -72,33 +72,6 @@ router.post("/", (async (req, res) => {
   }
 }) as RequestHandler);
 
-router.get("/", (async (req, res) => {
-  try {
-    const limit = parseInt(req.query.limit as string) || 10;
-    const lastEvaluatedKey = req.query.lastEvaluatedKey
-      ? JSON.parse(req.query.lastEvaluatedKey as string)
-      : undefined;
-
-    const params = {
-      TableName: TableNames.POSTS,
-      Limit: limit,
-      ...(lastEvaluatedKey && { ExclusiveStartKey: lastEvaluatedKey }),
-    };
-
-    const result = await dynamoDB.scan(params).promise();
-
-    res.json({
-      posts: result.Items || [],
-      ...(result.LastEvaluatedKey && {
-        lastEvaluatedKey: result.LastEvaluatedKey,
-      }),
-    });
-  } catch (error) {
-    console.error("Error fetching posts:", error);
-    res.status(500).json({ error: "Could not fetch posts" });
-  }
-}) as RequestHandler);
-
 router.get("/:postId", (async (req, res) => {
   try {
     const params = {


### PR DESCRIPTION
# What changed

Fixed issue of duplicate get (/) endpoints in the backend/routes/posts.ts file. Also fixed corresponding test case that fails with new get endpoint

# Why this change

Post feed wasn't displaying the author info and profile images bc it was using the old get endpoint that overrides the new get endpoint

# How was it tested

ran npm test to ensure the new test case passes and manually confirmed that author info and profile image shows up as expected.
